### PR TITLE
Removed post install

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "0.0.3",
   "description": "Stores all your client side and real time server validation logics in one place, plugin provides similar way of validation as aurelia does.",
   "scripts": {
-    "build": "typings i & gulp tslint & gulp clean-scripts & tsc & gulp clean-typings",
-    "postinstall": "typings i & tsc"
+    "build": "typings i & gulp tslint & gulp clean-scripts & tsc & gulp clean-typings"
   },
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
This should be done by the consumer. This also breaks applications that do not use tsc.